### PR TITLE
Preparing to remove the Entity API

### DIFF
--- a/TOC.json
+++ b/TOC.json
@@ -73,7 +73,8 @@
             "shortName": "Entity",
             "relPath": "Legacy/PlayFab/Entity.api.json",
             "format": "LegacyPlayFabApiSpec",
-            "sdkGenMakeMethods": ["makeClientAPI2", "makeServerAPI", "makeCombinedAPI"]
+            "sdkGenMakeMethods": ["makeClientAPI2", "makeServerAPI", "makeCombinedAPI"],
+            "isOptional": true
         },
         {
             "name": "PlayFabMatchmakerApi",


### PR DESCRIPTION
Will be replaced by a bunch of others, but at this step, it becomes optional again, so that the tests will pass once it's removed from pf-main.