### PR TITLE
removing PlayStreamModels from the TOC

### DIFF
--- a/TOC.json
+++ b/TOC.json
@@ -127,12 +127,6 @@
             "docKey": "PlayStreamProfileModels",
             "relPath": "Legacy/PlayFab/PlayStreamProfileModels.json",
             "format": "LegacyPlayFabModels"
-        },
-
-        {
-            "name": "PlayStreamModels",
-            "relPath": "Legacy/PlayFab/PlayStreamModels.json",
-            "format": "LegacyPlayFabModels"
         }
     ]
 }


### PR DESCRIPTION
didn't have a docKey, didn't have sdkGenMakeMethods, doesn't seem to be required for the TOC.