### PR TITLE
Removing the unused CharacterId parameter

### DIFF
--- a/Legacy/PlayFab/Server.api.json
+++ b/Legacy/PlayFab/Server.api.json
@@ -4438,13 +4438,6 @@
       "isRequest": true,
       "properties": [
         {
-          "name": "CharacterId",
-          "description": "Unique PlayFab assigned ID for a specific character owned by a user",
-          "jsontype": "String",
-          "actualtype": "String",
-          "optional": false
-        },
-        {
           "name": "CharacterType",
           "description": "Optional character type on which to filter the leaderboard entries.",
           "jsontype": "String",

--- a/Server.api.json
+++ b/Server.api.json
@@ -4438,13 +4438,6 @@
       "isRequest": true,
       "properties": [
         {
-          "name": "CharacterId",
-          "description": "Unique PlayFab assigned ID for a specific character owned by a user",
-          "jsontype": "String",
-          "actualtype": "String",
-          "optional": false
-        },
-        {
           "name": "CharacterType",
           "description": "Optional character type on which to filter the leaderboard entries.",
           "jsontype": "String",


### PR DESCRIPTION
from the server.GetCharacterLeaderboardRequest type.
This should fix a breaking regression test.