### PR TITLE
Localization and Multiplayer are no longer optional

### DIFF
--- a/TOC.json
+++ b/TOC.json
@@ -125,22 +125,21 @@
             "sdkGenMakeMethods": ["makeClientAPI2", "makeServerAPI", "makeCombinedAPI"]
         },
         {
-            "name": "PlayFabLocalizationApi",
-            "docKey": "LocalizationAPI",
-            "shortName": "Localization",
-            "relPath": "Legacy/PlayFab/Localization.api.json",
-            "format": "LegacyPlayFabApiSpec",
-            "sdkGenMakeMethods": ["makeServerAPI", "makeCombinedAPI"],
-            "isOptional": true
-        },
-        {
             "name": "PlayFabLeaderboardsApi",
             "docKey": "LeaderboardsAPI",
             "shortName": "Leaderboards",
             "relPath": "Legacy/PlayFab/Leaderboards.api.json",
             "format": "LegacyPlayFabApiSpec",
-            "sdkGenMakeMethods": ["makeServerAPI", "makeCombinedAPI"],
+            "sdkGenMakeMethods": ["makeClientAPI2", "makeServerAPI", "makeCombinedAPI"],
             "isOptional": true
+        },
+        {
+            "name": "PlayFabLocalizationApi",
+            "docKey": "LocalizationAPI",
+            "shortName": "Localization",
+            "relPath": "Legacy/PlayFab/Localization.api.json",
+            "format": "LegacyPlayFabApiSpec",
+            "sdkGenMakeMethods": ["makeClientAPI2", "makeServerAPI", "makeCombinedAPI"]
         },
         {
             "name": "PlayFabMultiplayerApi",
@@ -148,8 +147,7 @@
             "shortName": "Multiplayer",
             "relPath": "Legacy/PlayFab/Multiplayer.api.json",
             "format": "LegacyPlayFabApiSpec",
-            "sdkGenMakeMethods": ["makeServerAPI", "makeCombinedAPI"],
-            "isOptional": true
+            "sdkGenMakeMethods": ["makeClientAPI2", "makeServerAPI", "makeCombinedAPI"]
         },
         {
             "name": "PlayFabProfilesApi",


### PR DESCRIPTION
Multiple Entity API groups weren't always publishing to Client builds.
Alphabetizing Leaderboards ahead of Localization