### PR TITLE
Refactor fetch.js to avoid throttling

### DIFF
--- a/TOC.json
+++ b/TOC.json
@@ -358,7 +358,7 @@
         {
             "name": "PlayStreamProfileModel",
             "docKey": "PlayStreamProfileModel",
-            "pfurl": "apispec/PlayStreamProfileModels",
+            "pfurl": "apispec/PlayStreamProfileModel",
             "relPath": "Legacy/PlayFab/PlayStreamProfileModels.json",
             "format": "LegacyPlayFabModels"
         }

--- a/fetch.js
+++ b/fetch.js
@@ -1,107 +1,53 @@
-var https = require("https");
 var fs = require("fs");
 
-function WriteJsonFile(jsonBody, options) {
-    if (!jsonBody) {
-        console.log("  ***  Failed to write: " + options.description);
-        return false;
-    }
+const MAX_FETCH_RETRIES = 10;
+const FETCH_RETRY_DELAY = 200;
 
-    if (!options.outputFilename.endsWith(".json"))
-        options.outputFilename = options.outputFilename + ".json";
-    console.log("  -> Begin writing " + jsonBody.length + " bytes: " + options.description);
-    fs.writeFile(options.outputFilename, jsonBody, function (err) {
-        if (err)
-            return console.log(err);
-        console.log("  <- Finished writing: " + options.outputFilename);
+async function CompareLegacyApiListWithToc(fetchedList, tocObj) {
+    console.log("-> Begin CompareLegacyApiListWithToc");
+
+    var apiList = tocObj.documents.filter(obj => obj.format === "LegacyPlayFabApiSpec" || obj.format === "LegacyPlayFabModels");
+    const allElementsExist = fetchedList.every(fetchedApi => {
+        const urlPart = fetchedApi.url.split("/")[4];
+        const statusOk = fetchedApi.status === 200;
+        const hasMatch = apiList.some(api => urlPart === api.pfurl.split("/")[1]);
+        
+        return statusOk && hasMatch;
     });
 
+    if (!allElementsExist) {
+        throw "Current TOC does not match Swagger List or some fetched APIs did not return status 200.";
+    }
+
+    console.log(" <- Finished CompareLegacyApiListWithToc");
     return true;
 }
 
-function TabifyJson(inputJson, options) {
-    // console.log("  Begin tabifying: " + options.description);
+async function CompareSwaggerListWithToc(fetchedList, tocObj) {
+    console.log("-> Begin CompareSwaggerListWithToc");
 
-    if (!inputJson)
-        return null;
-
-    var output = null;
-    var tabSpaces = options.jsonTabSpaces;
-    if (!tabSpaces) tabSpaces = 2;
-    try {
-        var tempObj = JSON.parse(inputJson);
-        output = JSON.stringify(tempObj, null, tabSpaces);
-        // console.log("  Finish tabifying: " + options.description);
-    } catch (e) {
-        console.log("  ***  Failed to stringify: " + options.description);
-        output = null;
-    }
-
-    return output;
-}
-
-function UpdateVersionNumbers(rawResponse, options) {
-    console.log("  Begin version numbers");
-
-    var versionRe = new RegExp("([0-9]+)\.([0-9]+)\.[0-9][0-9][0-9][0-9][0-9][0-9]");
-    var now = new Date();
-    var todaysDate = (now.getUTCFullYear()%100).toString().padStart(2, "0") + (now.getMonth()+1).toString().padStart(2, "0") + (now.getUTCDate()).toString().padStart(2, "0");
-    var output = JSON.parse(rawResponse);
-    var versions = output.sdkVersion;
-    for (var i in versions) {
-        var eachTempVer = versions[i];
-        if (typeof(eachTempVer) !== "string") continue;
-        var reMatch = eachTempVer.match(versionRe);
-        if (!reMatch) continue;
-
-        var majorVer = parseInt(reMatch[1]);
-        var minorVer = parseInt(reMatch[2]);
-        if (majorVer !== 0 || minorVer !== 0)
-            minorVer++; // Increment the minor version here
-
-        versions[i] = majorVer.toString() + "." + minorVer.toString() + "." + todaysDate;
-    }
-
-    var processedResponse = TabifyJson(JSON.stringify(output), options);
-    if (processedResponse) {
-        return WriteJsonFile(processedResponse, options);
-    }
-    return false;
-}
-
-function GetFileFromUrl(inputUrl, options, retry = 0) {
-    if (retry == 10) {
-        var msg = "  !!!!!!!!!!  Aborting GetFileFromUrl, failed " + retry + " times: " + inputUrl;
-        console.log(msg); return; // throw Error(msg);
-    }
-
-    console.log("-> Begin reading: " + inputUrl);
-    var rawResponse = "";
-    var postReq = https.get(inputUrl, function (res) {
-        res.setEncoding("utf8");
-        res.on("data", function (chunk) { rawResponse += chunk; });
-        res.on("end", function () {
-            console.log("<- Finished reading " + rawResponse.length + " bytes: " + inputUrl);
-            var processedResponse = rawResponse;
-            if (options.expectJson) {
-                processedResponse = TabifyJson(rawResponse, options);
-            }
-            var callbackSuccess = res.statusCode == 200;
-            if (callbackSuccess && options.onFileDownload) {
-                callbackSuccess = options.onFileDownload(processedResponse, options);
-            }
-            if (!callbackSuccess) {
-                console.log("  !!!  Failed to GetFileFromUrl (retry: " + retry + ", " + res.statusCode + "): " + inputUrl );
-                GetFileFromUrl(inputUrl, options, retry + 1)
-            }
-        });
+    var swaggerList = tocObj.documents.filter(obj => obj.format === "Swagger")
+    const allElementsExist = fetchedList.every(fetchedApi => {
+        const urlPart = fetchedApi.url.split("/")[4];
+        const statusOk = fetchedApi.status === 200;
+        const hasMatch = swaggerList.some(swaggerApi => urlPart === swaggerApi.pfurl.split("/")[1]);
+        
+        return statusOk && hasMatch;
     });
+
+    if (!allElementsExist) {
+        throw "Current TOC does not match Swagger List or some fetched APIs did not return status 200.";
+    }
+
+    console.log(" <- Finished CompareSwaggerListWithToc");
+    return true;
 }
 
 function ExtractArgs(args) {
     var cmdArgs = args.slice(2, args.length);
     var argsByName = {};
     var activeKey = null;
+
     for (var i = 0; i < cmdArgs.length; i++) {
         if (cmdArgs[i].indexOf("-") === 0) {
             activeKey = cmdArgs[i].substring(1);
@@ -116,158 +62,185 @@ function ExtractArgs(args) {
                 argsByName[activeKey] = cmdArgs[i];
         }
     }
-
-    // Pull from environment variables?
-    // process.env.hasOwnProperty("varname")
     return argsByName;
+}
+
+async function FetchDataFromUrl(url) {
+    console.log("-> Begin reading: " + url);
+
+    return new Promise((resolve, reject) => {
+        const attemptFetch = async (n) => {
+            try {
+                const response = await fetch(url);
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status} ${response.statusText} on ${url}`);
+                }
+
+                const result = {
+                    url: url,
+                    response: await response.json(),
+                    status: response.status
+                }
+                console.log("  <- Finished reading: " + url);
+
+                resolve(result);
+            } catch (error) {
+                if (n <= MAX_FETCH_RETRIES) {
+                    console.warn(error);
+                    console.warn(`Retrying... (${n})`);
+                    setTimeout(() => attemptFetch(n + 1), backoffDelay(n));
+                } else {
+                    reject(error);
+                }
+            }
+        };
+        attemptFetch(1);
+    });
+}
+
+async function FetchLegacyApis(playFabUrl, tocObj) {
+    console.log("-> Begin FetchLegacyApis");
+
+    var apiList = tocObj.documents.filter(obj => obj.format === "LegacyPlayFabApiSpec" || obj.format === "LegacyPlayFabModels");
+    var fetchedList = [];
+
+    for (const api of apiList) {
+        try {
+            const data = await FetchDataFromUrl(`${playFabUrl}${api.pfurl}`);
+            fetchedList.push(data);
+        } catch (error) {
+            console.error("!!!!!!!!!! Aborting fetchLegacyApis, failed\n", error);
+        }
+    }
+
+    console.log("<- Finished FetchLegacyApis");
+
+    return fetchedList;
+}
+
+async function FetchSwaggerApiGroupList(swaggerApiListUrl, tocObj) {
+    var swaggerList = tocObj.documents.filter(obj => obj.format === "Swagger")
+    var fetchedList = [];
+
+    for (const api of swaggerList) {
+        try {
+            const data = await FetchDataFromUrl(`${swaggerApiListUrl}${api.pfurl}`);
+            fetchedList.push(data);
+        } catch (error) {
+            console.error("  !!!!!!!!!!  Aborting FetchDataFromUrl, failed\n", error);
+        }
+    }
+
+    return fetchedList;
 }
 
 function GetPlayFabUrl() {
     var argsDict = ExtractArgs(process.argv);
     var verticalUrl = "www";
-    var playFabUrl = "https://"+verticalUrl+".playfabapi.com/";
+    var playFabUrl = "https://" + verticalUrl + ".playfabapi.com/";
+
     if (argsDict["playFabUrl"])
         playFabUrl = argsDict["playFabUrl"];
     if (!playFabUrl.endsWith("/"))
         playFabUrl = playFabUrl + "/";
+
     return playFabUrl;
 }
 
-function UpdateApiFilesFromToc(playFabUrl, tocObj) {
+function backoffDelay(n) {
+    return Math.pow(2, n) * FETCH_RETRY_DELAY;
+}
+
+async function UpdateApiFiles(jsonToUploadList, tocObj) {
+    console.log("-> Begin UpdateApiFiles");
+
     try {
-        for (var i = 0; i < tocObj.documents.length; ++i) {
-            var apiSection = tocObj.documents[i];
-            if (apiSection.format === "LegacyPlayFabApiSpec" || apiSection.format === "Swagger") {
-                var eachApiOpt = {
-                    description: apiSection.relPath,
-                    expectJson: true,
-                    jsonTabSpaces: 2,
-                    outputFilename: apiSection.relPath,
-                    onFileDownload: WriteJsonFile
-                }
-                GetFileFromUrl(playFabUrl + apiSection.pfurl, eachApiOpt);
-            }
+        for (var api of jsonToUploadList) {
+            const apiName = api.url.split("/")[4];
+            const filepath = tocObj.documents.find(d => d.pfurl.split("/")[1] === apiName).relPath;
+            await WriteFetchedData(api.response, filepath, 2);
         }
-    } catch(err) {
-        console.log("=== fetch.js failed to parse TOC.json as JSON :( ===");
-        console.log(err);
+    } catch (error) {
+        console.error("  !!!!!!!!!!  Aborting UpdateApiFilesFromToc, failed\n", error);
     }
+
+    console.log("<- Finished UpdateApiFiles");
 }
 
-function UpdateSdkManualNotes() {
-    var versionOpt = {
-        description: "SdkManualNotes",
-        expectJson: true,
-        jsonTabSpaces: 4,
-        outputFilename: "SdkManualNotes.json",
-        onFileDownload: UpdateVersionNumbers
+async function UpdateSdkManualNotes() {
+    console.log("-> Begin SdkManualNotes");
+
+    try {
+        const sdkManualNotesUrl = "https://raw.githubusercontent.com/PlayFab/API_Specs/master/SdkManualNotes.json";
+        var data = await FetchDataFromUrl(sdkManualNotesUrl);
+        await UpdateVersionNumbers(data);
+    } catch (error) {
+        console.error("  !!!!!!!!!!  Aborting FetchDataFromUrl, failed\n", error);
     }
-    GetFileFromUrl("https://raw.githubusercontent.com/PlayFab/API_Specs/master/SdkManualNotes.json", versionOpt);
+
+    console.log("<- Finished SdkManualNotes");
 }
 
-// Find Api Groups from the TOC or legacy Api list, which don't exist in the other
-function CheckLegacyApiGroupList(playFabUrl, tocObj, isAzure) {
-    var legacyApiListUrl;
-    var description;
+async function UpdateVersionNumbers(data) {
+    console.log("-> Begin version numbers");
 
-    if (isAzure) {
-        legacyApiListUrl = playFabUrl + "azure/apispec/";
-        description = "azureLegacyApiList";
-    } else {
-        legacyApiListUrl = playFabUrl + "apispec/";
-        description = "legacyApiList";
-    }
-
-    var apiList = tocObj.documents.filter(obj =>
-        obj.format === "LegacyPlayFabApiSpec" || obj.format === "LegacyPlayFabModels"
-    )
-
-    var options = {
-        description: description,
-        expectJson: true,
-        jsonTabSpaces: 0,
-        tocRef: apiList,
-        onFileDownload: CompareApiListWithToc
-    };
-    GetFileFromUrl(legacyApiListUrl, options);
-}
-
-function CompareApiListWithToc(apis, options) {
-    var apiList = JSON.parse(apis);
-    // Check if all elements from the incoming API list exist in the TOC
-    var allElementsExist = apiList.every(element => 
-        options.tocRef.some(obj => obj.docKey === element)); // The incoming API name is a subset of the TOC.document.name
-    if(!allElementsExist) {
-        throw "Current TOC does not match API List.\n TOC: " + JSON.stringify(options.tocRef, apiListReplacer, 2) + "\n API List: " + apis;
-    }
-    return true;
-}
-
-function apiListReplacer(key, value) {
-    if (key === "" || key === "docKey") {
-      return value;
-    }
-    if (typeof value === "object" && value !== null) {
-        return { docKey: value.docKey };
-    }
-    return undefined;
-}
-
-// Find Api Groups from the TOC or swagger Api list, which don't exist in the other
-function CheckSwaggerApiGroupList(playFabUrl, tocObj, isAzure) {
-    var swaggerApiListUrl;
-    var description;
+    var response = data.response;
+    var versionRe = new RegExp("([0-9]+)\.([0-9]+)\.[0-9][0-9][0-9][0-9][0-9][0-9]");
+    var now = new Date();
+    var todaysDate = (now.getUTCFullYear() % 100).toString().padStart(2, "0") + (now.getMonth() + 1).toString().padStart(2, "0") + (now.getUTCDate()).toString().padStart(2, "0");
+    var versions = response.sdkVersion;
     
-    if (isAzure) {
-        swaggerApiListUrl = playFabUrl + "azure/swagger/";
-        description = "azureLegacySwaggerList";
-    } else {
-        swaggerApiListUrl = playFabUrl + "swagger/";
-        description = "legacySwaggerList";
+    for (var i in versions) {
+        var eachTempVer = versions[i];
+        if (typeof (eachTempVer) !== "string") continue;
+        var reMatch = eachTempVer.match(versionRe);
+        if (!reMatch) continue;
+        var majorVer = parseInt(reMatch[1]);
+        var minorVer = parseInt(reMatch[2]);
+        if (majorVer !== 0 || minorVer !== 0) {
+            minorVer++;
+        }
+        versions[i] = majorVer.toString() + "." + minorVer.toString() + "." + todaysDate;
     }
 
-    var swaggerList = tocObj.documents.filter(obj => obj.format === "Swagger")
-
-    var options = {
-        description: description,
-        expectJson: true,
-        jsonTabSpaces: 0,
-        tocRef: swaggerList,
-        onFileDownload: CompareSwaggerListWithToc
-    };
-    GetFileFromUrl(swaggerApiListUrl, options);
+    await WriteFetchedData(response, "SdkManualNotes.json", 4);
+    console.log("<- Finished version numbers");
 }
 
-function CompareSwaggerListWithToc(swagger, options) {
-    var swaggerList = JSON.parse(swagger);
-    // Check if all elements from the incoming Swagger list exist in the TOC
-    var allElementsExist = swaggerList.every(element =>
-       options.tocRef.some(obj => element.includes(obj.pfurl.split("/")[1]))); // TOC.document.pfurl is a subset the incoming Swagger entry
-    if(!allElementsExist) {
-        throw "Current TOC does not match Swagger List. \nTOC: " + JSON.stringify(options.tocRef, swaggerListReplacer, 2) + "\n Swagger: " + swagger;
+async function WriteFetchedData(response, filePath, spaces = 2) {
+    console.log(`-> Writing: ${filePath}`);
+
+    if (response == null) {
+        console.log("Nothing to write, response is null");
+        return false;
     }
-    return true;
+
+    return new Promise((resolve, reject) => {
+        fs.writeFile(filePath, JSON.stringify(response, null, spaces), function (err) {
+            if (err) {
+                console.log(err);
+                reject(err);
+            } else {
+                console.log(`<- Finished writing: ${filePath}`);
+                resolve(true);
+            }
+        });
+    });
 }
 
-function swaggerListReplacer(key, value) {
-    if (key === "" || key === "pfurl") {
-      return value;
-    }
-    if (typeof value === "object" && value !== null) {
-        return { pfurl: value.pfurl.split("/")[1] };
-    }
-    return undefined;
-}
-
-function DoWork() {
+async function DoWork() {
     var playFabUrl = GetPlayFabUrl();
     var tocObj = require("./TOC.json");
 
-    UpdateApiFilesFromToc(playFabUrl, tocObj);
+    var fetchedLegacyApis = await FetchLegacyApis(playFabUrl, tocObj);
+    await CompareLegacyApiListWithToc(fetchedLegacyApis, tocObj);
+    await UpdateApiFiles(fetchedLegacyApis, tocObj);
+
+    var fetchedSwaggerApis = await FetchSwaggerApiGroupList(playFabUrl, tocObj);
+    await CompareSwaggerListWithToc(fetchedSwaggerApis, tocObj);
+    await UpdateApiFiles(fetchedSwaggerApis, tocObj);
+
     UpdateSdkManualNotes();
-    CheckLegacyApiGroupList(playFabUrl, tocObj);
-    CheckSwaggerApiGroupList(playFabUrl, tocObj);
-    
-    // TODO: Some kind of final global report, with an errors list from all threads
 }
+
 DoWork();

--- a/fetch.js
+++ b/fetch.js
@@ -7,12 +7,10 @@ async function CompareLegacyApiListWithToc(fetchedList, tocObj) {
     console.log("-> Begin CompareLegacyApiListWithToc");
 
     var apiList = tocObj.documents.filter(obj => obj.format === "LegacyPlayFabApiSpec" || obj.format === "LegacyPlayFabModels");
-    const allElementsExist = fetchedList.every(fetchedApi => {
-        const urlPart = fetchedApi.url.split("/")[4];
-        const statusOk = fetchedApi.status === 200;
-        const hasMatch = apiList.some(api => urlPart === api.pfurl.split("/")[1]);
-        
-        return statusOk && hasMatch;
+
+    const allElementsExist = apiList.every(api => {
+        const urlPart = api.pfurl.split("/")[1]
+        return fetchedList.some(fetchedApi =>  urlPart === fetchedApi.url.split("/")[4] && fetchedApi.status === 200);
     });
 
     if (!allElementsExist) {
@@ -27,12 +25,9 @@ async function CompareSwaggerListWithToc(fetchedList, tocObj) {
     console.log("-> Begin CompareSwaggerListWithToc");
 
     var swaggerList = tocObj.documents.filter(obj => obj.format === "Swagger")
-    const allElementsExist = fetchedList.every(fetchedApi => {
-        const urlPart = fetchedApi.url.split("/")[4];
-        const statusOk = fetchedApi.status === 200;
-        const hasMatch = swaggerList.some(swaggerApi => urlPart === swaggerApi.pfurl.split("/")[1]);
-        
-        return statusOk && hasMatch;
+    const allElementsExist = swaggerList.every(swaggerApi => {
+        const urlPart = swaggerApi.pfurl.split("/")[1];
+       return fetchedList.some(api => urlPart === api.url.split("/")[4] && api.status === 200);
     });
 
     if (!allElementsExist) {
@@ -162,6 +157,7 @@ async function UpdateApiFiles(jsonToUploadList, tocObj) {
         }
     } catch (error) {
         console.error("  !!!!!!!!!!  Aborting UpdateApiFiles, failed\n", error);
+        throw error;
     }
 
     console.log("<- Finished UpdateApiFiles");
@@ -176,6 +172,7 @@ async function UpdateSdkManualNotes() {
         await UpdateVersionNumbers(data);
     } catch (error) {
         console.error("  !!!!!!!!!!  Aborting UpdateSdkManualNotes, failed\n", error);
+        throw error;
     }
 
     console.log("<- Finished SdkManualNotes");

--- a/fetch.js
+++ b/fetch.js
@@ -240,7 +240,7 @@ async function DoWork() {
     await CompareSwaggerListWithToc(fetchedSwaggerApis, tocObj);
     await UpdateApiFiles(fetchedSwaggerApis, tocObj);
 
-    UpdateSdkManualNotes();
+    await UpdateSdkManualNotes();
 }
 
 DoWork();

--- a/fetch.js
+++ b/fetch.js
@@ -16,7 +16,7 @@ async function CompareLegacyApiListWithToc(fetchedList, tocObj) {
     });
 
     if (!allElementsExist) {
-        throw "Current TOC does not match Swagger List or some fetched APIs did not return status 200.";
+        throw "Current TOC does not match Legacy List or some fetched APIs did not return status 200.";
     }
 
     console.log(" <- Finished CompareLegacyApiListWithToc");
@@ -109,7 +109,7 @@ async function FetchLegacyApis(playFabUrl, tocObj) {
             const data = await FetchDataFromUrl(`${playFabUrl}${api.pfurl}`);
             fetchedList.push(data);
         } catch (error) {
-            console.error("!!!!!!!!!! Aborting fetchLegacyApis, failed\n", error);
+            console.error("!!!!!!!!!! Aborting FetchLegacyApis, failed\n", error);
         }
     }
 
@@ -127,7 +127,7 @@ async function FetchSwaggerApiGroupList(swaggerApiListUrl, tocObj) {
             const data = await FetchDataFromUrl(`${swaggerApiListUrl}${api.pfurl}`);
             fetchedList.push(data);
         } catch (error) {
-            console.error("  !!!!!!!!!!  Aborting FetchDataFromUrl, failed\n", error);
+            console.error("  !!!!!!!!!!  Aborting FetchSwaggerApiGroupList, failed\n", error);
         }
     }
 
@@ -161,7 +161,7 @@ async function UpdateApiFiles(jsonToUploadList, tocObj) {
             await WriteFetchedData(api.response, filepath, 2);
         }
     } catch (error) {
-        console.error("  !!!!!!!!!!  Aborting UpdateApiFilesFromToc, failed\n", error);
+        console.error("  !!!!!!!!!!  Aborting UpdateApiFiles, failed\n", error);
     }
 
     console.log("<- Finished UpdateApiFiles");
@@ -175,7 +175,7 @@ async function UpdateSdkManualNotes() {
         var data = await FetchDataFromUrl(sdkManualNotesUrl);
         await UpdateVersionNumbers(data);
     } catch (error) {
-        console.error("  !!!!!!!!!!  Aborting FetchDataFromUrl, failed\n", error);
+        console.error("  !!!!!!!!!!  Aborting UpdateSdkManualNotes, failed\n", error);
     }
 
     console.log("<- Finished SdkManualNotes");


### PR DESCRIPTION
- Replace `http.get` to `fetch` methods to increase readabitlity and mantainance.
- Refactor the Fetch.js script to wait before sending another request to the server.
- Separate logic to fetch data from check and update.
- Order code to ease the maintenance.
- Remove duplicated calls from updating apis files and checkers.
- Added delay after each failed request.
- Added logging to each function for future debugging.
- fix incorrect url in toc.json for `PlayStreamProfileModel` to avoid 404 errors.

